### PR TITLE
チャットメッセージを投稿直後にJSで表示する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+dev-log.md

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,11 @@ class MessagesController < ApplicationController
     @message.role = "user"
 
     if @session.save
-      head :ok
+      if @session.previously_new_record?
+        head :created, location: session_path(@session)
+      else
+        head :ok
+      end
     else
       head :unprocessable_entity
     end

--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -12,21 +12,27 @@ export default class extends Controller {
     const formData = new FormData()
     formData.append("message[body]", body)
 
-    const response = await fetch(this.element.action, {
-      method: "POST",
-      body: formData,
-      headers: {
-        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
-      }
-    })
+    try {
+      const response = await fetch(this.element.action, {
+        method: "POST",
+        body: formData,
+        headers: {
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+        }
+      })
 
-    if (response.ok) {
-      const location = response.headers.get("Location")
-      if (location) {
-        window.location.href = location
+      if (response.ok) {
+        const location = response.headers.get("Location")
+        if (location) {
+          window.location.href = location
+        } else {
+          this.appendMessage(body)
+        }
       } else {
-        this.appendMessage(body)
+        console.error("予期せぬレスポンス:", response.status)
       }
+    } catch (error) {
+      console.error("通信エラー:", error)
     }
     this.inputTarget.value = ""
   }

--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -3,14 +3,16 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["input"]
 
-  send(e) {
+  async send(e) {
     e.preventDefault()
     if (this.inputTarget.value.trim() === "") return
 
-    const formData = new FormData()
-    formData.append("message[body]", this.inputTarget.value)
+    const body = this.inputTarget.value
 
-    fetch(this.element.action, {
+    const formData = new FormData()
+    formData.append("message[body]", body)
+
+    const response = await fetch(this.element.action, {
       method: "POST",
       body: formData,
       headers: {
@@ -18,6 +20,29 @@ export default class extends Controller {
       }
     })
 
+    if (response.ok) {
+      const location = response.headers.get("Location")
+      if (location) {
+        window.location.href = location
+      } else {
+        this.appendMessage(body)
+      }
+    }
     this.inputTarget.value = ""
+  }
+
+  appendMessage(body) {
+    const container = document.getElementById("chat")
+    const outer = document.createElement("div")
+    outer.className = "user-message flex justify-end"
+    const inner = document.createElement("div")
+    inner.className = "bg-chat rounded-lg p-4 max-w-xs"
+    const p = document.createElement("p")
+    p.textContent = body
+
+    inner.appendChild(p)
+    outer.appendChild(inner)
+    container.appendChild(outer)
+    outer.scrollIntoView({ behavior: "smooth" })
   }
 }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,5 +16,9 @@ RSpec.configure do |config|
     else
       driven_by :selenium, using: :headless_chrome
     end
+    ActionController::Base.allow_forgery_protection = true
+  end
+  config.after(:each, type: :system) do
+    ActionController::Base.allow_forgery_protection = false
   end
 end

--- a/spec/system/chat_spec.rb
+++ b/spec/system/chat_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Chat message", type: :system do
+  before do
+    sign_in_with_google
+  end
+
+  describe "sends a message to an existing session" do
+    let!(:chat_session) { create(:session, user: User.last) }
+
+    before do
+      visit session_path(chat_session)
+    end
+
+    it "appears in the chat thread after sent" do
+      fill_in "message_body", with: "hello"
+      find('input[type="submit"]').click
+      expect(page).to have_content("hello")
+    end
+
+    it "disappears from the chat form after sent" do
+      fill_in "message_body", with: "chao"
+      find('input[type="submit"]').click
+      expect(page).to have_field("message_body", with: "")
+    end
+
+    it "cannot be sent when it is empty" do
+      find('input[type="submit"]').click
+      expect(page).to have_no_css(".user-message")
+    end
+  end
+end

--- a/spec/system/menu_spec.rb
+++ b/spec/system/menu_spec.rb
@@ -1,4 +1,3 @@
-# spec/system/menu_spec.rb
 require "rails_helper"
 
 RSpec.describe "Menu", type: :system do


### PR DESCRIPTION
### Issue
#50 

### 概要
- fetch API使用
- 新規sessionの場合はlocation: session_path(@session)を返却。JSでリダイレクト。
- 新規の場合はhead: okのみ返却し、HTMLをDOMにappend
- system spec追加
- test環境において、sytem specの実行時のみcsrfトークンを有効に設定