### PR TITLE
AI回答待ちの間にローダーを表示する

### DIFF
--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+	static targets = ["loader", "container"];
+
+	showLoader() {
+		this.containerTarget.appendChild(this.loaderTarget);
+		this.loaderTarget.classList.remove("hidden");
+	}
+
+	hideLoader(e) {
+		const stream = e.detail.newStream;
+		if (stream.getAttribute("target") === "chat") {
+			this.loaderTarget.classList.add("hidden");
+		}
+	}
+}

--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -47,6 +47,8 @@ export default class extends Controller {
 			}
 		} catch (error) {
 			console.error("通信エラー:", error);
+		} finally {
+			this.dispatch("submitted");
 		}
 		this.inputTarget.value = "";
 	}

--- a/app/views/sessions/show.html.slim
+++ b/app/views/sessions/show.html.slim
@@ -1,13 +1,13 @@
 = turbo_stream_from @session
 
 dev.flex.flex-col.h-screen(
-    data-controller="video-capture photo-capture photo-select"
+    data-controller="video-capture photo-capture photo-select chat"
     data-video-capture-prep-duration-value="5000"
     data-video-capture-interval-duration-value="8000"
     data-video-capture-total-shots-value="6"
-    data-action="photo-capture:complete->photo-select#show"
+    data-action="photo-capture:complete->photo-select#show chat-form:submitted->chat#showLoader turbo:before-stream-render@document->chat#hideLoader"
   )
-  section#chat.flex-1.overflow-y-auto.p-4.flex.flex-col.gap-4
+  section#chat.flex-1.overflow-y-auto.p-4.flex.flex-col.gap-4 data-chat-target="container"
     - @session_messages.each do |message|
       - if message.user?
         div.user-message.flex.justify-end
@@ -16,6 +16,9 @@ dev.flex.flex-col.h-screen(
 
       - else
         = render "messages/ai_message", message: message, diagnosed_images: message.diagnosed_images
+      
+    div.loader.hidden data-chat-target="loader"
+      | loading...
 
   = render "shared/video_capture"
   = render "shared/photo_capture"


### PR DESCRIPTION
### Issue
#125

### 概要
AI回答待ちの間に「Loading...」とだけ表示し、回答表示直前に非表示にする。デザインは後回し。

### 実装方針
- chatセクションのユーティリティ全般を担当するchat-controller.jsを作成。loaderを制御する。
- Loaderの表示: フォーム送信後にカスタムイベントをdispatch。 chat#showLoaderで表示。
- Loaderの非表示: turbo:before-stream-renderイベントを補足し、chat#hideLoaderで非表示。