### PR TITLE
DOMに追加された最新の要素に自動でスクロールする

### DIFF
--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -3,6 +3,37 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
 	static targets = ["loader", "container"];
 
+	connect() {
+		this.startObserve();
+	}
+
+	startObserve() {
+		const config = {
+			childList: true,
+			attributes: false,
+			subtree: true,
+		};
+
+		const callback = (mutationList, observer) => {
+			const hasAddedNode = mutationList.some((mutationRecord) => {
+				return (
+					mutationRecord.type === "childList" &&
+					mutationRecord.addedNodes.length > 0
+				);
+			});
+
+			if (hasAddedNode) {
+				this.containerTarget.lastElementChild.scrollIntoView({
+					behavior: "smooth",
+					block: "end",
+				});
+			}
+		};
+
+		this.observer = new MutationObserver(callback);
+		this.observer.observe(this.containerTarget, config);
+	}
+
 	showLoader() {
 		this.containerTarget.appendChild(this.loaderTarget);
 		this.loaderTarget.classList.remove("hidden");
@@ -13,5 +44,9 @@ export default class extends Controller {
 		if (stream.getAttribute("target") === "chat") {
 			this.loaderTarget.classList.add("hidden");
 		}
+	}
+
+	disconnect() {
+		this.observer.disconnect();
 	}
 }

--- a/app/javascript/controllers/image_controller.js
+++ b/app/javascript/controllers/image_controller.js
@@ -37,14 +37,17 @@ export default class extends Controller {
 		}
 	}
 
-	show(records) {
+	async show(records) {
 		if (records.length === 0) return;
-		records.forEach((record) => {
+		for (const record of records) {
 			const img = document.createElement("img");
-			console.log("imageTag created!!");
 			img.src = URL.createObjectURL(record.blob);
-			console.log("url created!!", img.src);
-			this.garellyTarget.appendChild(img);
-		});
+			try {
+				await img.decode();
+				this.garellyTarget.appendChild(img);
+			} catch (e) {
+				console.error("Decode failded:", e);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Issue
#127 

### 概要
既存のチャットで常にDOMに追加された最新の要素にスクロールする

### 背景
メッセージ送信後にユーザーが手動でスクロールするUXの改善

### 実装方針
- MutationObserverでチャットコンテナのDOM変更を監視
- Stimulusのconnect/disconnectでObserverのライフサイクルを管理
- scrollIntoView({block: "end"})で要素下端にスクロール
