### PR TITLE
画像アスペクトを9:16の縦型に統一

### DIFF
--- a/app/javascript/controllers/photo_capture_controller.js
+++ b/app/javascript/controllers/photo_capture_controller.js
@@ -63,9 +63,13 @@ export default class extends Controller {
 		const canvas = this.canvasTarget;
 		const ctx = canvas.getContext("2d");
 
-		canvas.width = video.videoWidth;
-		canvas.height = video.videoHeight;
-		ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+		const srcHeight = video.videoHeight;
+		const srcWidth = srcHeight * (9 / 16);
+		const sx = (video.videoWidth - srcWidth) / 2;
+
+		canvas.width = srcWidth;
+		canvas.height = srcHeight;
+		ctx.drawImage(video, sx, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight);
 
 		return new Promise((resolve) => {
 			canvas.toBlob((blob) => resolve(blob), "image/jpeg", 0.8);

--- a/app/javascript/controllers/video_capture_controller.js
+++ b/app/javascript/controllers/video_capture_controller.js
@@ -75,9 +75,14 @@ export default class extends Controller {
 		const canvas = this.canvasTarget;
 		const ctx = canvas.getContext("2d");
 
-		canvas.width = video.videoWidth;
-		canvas.height = video.videoHeight;
-		ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+		const srcHeight = video.videoHeight;
+		const srcWidth = srcHeight * (9 / 16);
+		const sx = (video.videoWidth - srcWidth) / 2;
+
+		canvas.width = srcWidth;
+		canvas.height = srcHeight;
+
+		ctx.drawImage(video, sx, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight);
 
 		return new Promise((resolve) => {
 			canvas.toBlob((blob) => resolve(blob), "image/jpeg", 0.8);

--- a/app/views/shared/_photo_capture.html.slim
+++ b/app/views/shared/_photo_capture.html.slim
@@ -1,5 +1,5 @@
 div.fixed.inset-0.z-50.bg-black.flex.flex-col.hidden data-photo-capture-target="screen"
-  div.relative.flex-1.overflow-hidden
+  div class="relative mx-auto flex-1 aspect-9/16 max-h-[90vh] overflow-hidden"
     video.w-full.h-full.object-cover data-photo-capture-target="video" autoplay playsinline muted
     canvas.hidden data-photo-capture-target="canvas"
     div.absolute.inset-0.bg-white.opacity-0.pointer-events-none.transition-opacity.duration-150 data-photo-capture-target="flash"

--- a/app/views/shared/_video_capture.html.slim
+++ b/app/views/shared/_video_capture.html.slim
@@ -1,10 +1,9 @@
 div.fixed.inset-0.z-50.bg-black.hidden data-video-capture-target="screen"
-  div.h-full
-    div.relative.w-full.h-full
-      video.w-full.h-full.object-cover data-video-capture-target="video" autoplay playsinline muted
-      canvas.hidden data-video-capture-target="canvas"
-      span.absolute.top-4.left-4.text-red-500.font-bold.hidden data-video-capture-target="rec"
-        | REC
-      button.absolute.top-4.right-4.text-white.text-3xl type="button" aria-label="閉じる" data-action="click->video-capture#close"
-        | ✕
-      button.absolute.bottom-12.left-1/2.-translate-x-1/2.w-16.h-16.rounded-full.border-4.border-white type="button" aria-label="撮影" data-action="click->video-capture#start"
+  div class="relative mx-auto aspect-9/16 max-h-[90vh] overflow-hidden"
+    video.w-full.h-full.object-cover data-video-capture-target="video" autoplay playsinline muted
+    canvas.hidden data-video-capture-target="canvas"
+    span.absolute.top-4.left-4.text-red-500.font-bold.hidden data-video-capture-target="rec"
+      | REC
+    button.absolute.top-4.right-4.text-white.text-3xl type="button" aria-label="閉じる" data-action="click->video-capture#close"
+      | ✕
+    button.absolute.bottom-12.left-1/2.-translate-x-1/2.w-16.h-16.rounded-full.border-4.border-white type="button" aria-label="撮影" data-action="click->video-capture#start"


### PR DESCRIPTION
### Issue
#128 

### 概要
アプリ内で撮影・表示する画像の比率を統一的に9:16の縦型に固定。

### 実装方針
- tailwindCSSでaspectクラスを追加し、撮影のプレビュー画面を9:16で表示
- video(とphoto)_capture_controller.jsにてvideo streamとcanvasのサイズをそれぞれ9:16に合わせ、撮影・保存。
