### PR TITLE
サムネイルのサイズとレイアウトを調整する

### DIFF
--- a/app/javascript/controllers/image_controller.js
+++ b/app/javascript/controllers/image_controller.js
@@ -42,6 +42,7 @@ export default class extends Controller {
 		for (const record of records) {
 			const img = document.createElement("img");
 			img.src = URL.createObjectURL(record.blob);
+			img.classList.add("w-full", "aspect-square", "object-cover", "rounded");
 			try {
 				await img.decode();
 				this.garellyTarget.appendChild(img);

--- a/app/views/messages/_ai_message.html.slim
+++ b/app/views/messages/_ai_message.html.slim
@@ -7,4 +7,4 @@ div.ai-message.flex.flex-col.items-start id=dom_id(message) data-controller="ima
     button type="button" aria-label="グッドボタン" 👍
     button type="button" aria-label="バッドボタン" 👎
     button type="button" aria-label="コピー" 📋
-  div.diagnosed-images.flex.gap-2 data-image-target="garelly"
+  div.diagnosed-images.grid.grid-cols-3.gap-2 data-image-target="garelly"


### PR DESCRIPTION
### Issue
#129

### 概要
現状、縦型の画像が横一列に並び、画面幅をはみ出して表示されている。サイズとレイアウトを調整する。画像最大6枚の場合、3枚・2段(モバイル)

### 実装方針
- サムネイルの比率を1:1にする
- CSS Gridでレイアウト