### PR TITLE
画像プレビュー画面を作成

### DIFF
--- a/app/javascript/controllers/image_controller.js
+++ b/app/javascript/controllers/image_controller.js
@@ -43,6 +43,7 @@ export default class extends Controller {
 			const img = document.createElement("img");
 			img.src = URL.createObjectURL(record.blob);
 			img.classList.add("w-full", "aspect-square", "object-cover", "rounded");
+			img.setAttribute("data-action", "click->image-preview#showImagePreview");
 			try {
 				await img.decode();
 				this.garellyTarget.appendChild(img);

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+	static targets = ["screen", "frame"];
+
+	showImagePreview(e) {
+		this.frameTarget.src = e.currentTarget.src;
+		this.screenTarget.classList.remove("hidden");
+	}
+
+	closeImagePreview() {
+		this.screenTarget.classList.add("hidden");
+		this.frameTarget.src = "";
+	}
+}

--- a/app/views/sessions/show.html.slim
+++ b/app/views/sessions/show.html.slim
@@ -1,7 +1,7 @@
 = turbo_stream_from @session
 
 dev.flex.flex-col.h-screen(
-    data-controller="video-capture photo-capture photo-select chat"
+    data-controller="video-capture photo-capture photo-select chat image-preview"
     data-video-capture-prep-duration-value="5000"
     data-video-capture-interval-duration-value="8000"
     data-video-capture-total-shots-value="6"
@@ -19,7 +19,8 @@ dev.flex.flex-col.h-screen(
       
     div.loader.hidden data-chat-target="loader"
       | loading...
-
+  
+  = render "shared/image_preview"
   = render "shared/video_capture"
   = render "shared/photo_capture"
   = render "shared/photo_select"

--- a/app/views/shared/_image_preview.html.slim
+++ b/app/views/shared/_image_preview.html.slim
@@ -1,0 +1,7 @@
+div.fixed.inset-0.z-50.flex.flex-col.bg-black.hidden data-image-preview-target="screen"
+  div.flex.justify-end.p-4
+    button.text-white.text-3xl type="button" data-action="click->image-preview#closeImagePreview"
+      | ×
+
+  div.flex-1.flex.items-center.justify-center
+   img.max-h-full.max-w-full.object-contain src="" data-image-preview-target="frame"


### PR DESCRIPTION
### Issue
#130 

### 概要
サムネイルをクリックし画像をプレビューできるようにする

### 実装方針
- サムネイルをDOMにappendする際、それぞれのimg要素にdata-action=click->image-preview#showImagePreview属性を追加