### PR TITLE
撮影アスペクトを3:4に変更

### DIFF
--- a/app/javascript/controllers/photo_capture_controller.js
+++ b/app/javascript/controllers/photo_capture_controller.js
@@ -63,13 +63,24 @@ export default class extends Controller {
 		const canvas = this.canvasTarget;
 		const ctx = canvas.getContext("2d");
 
-		const srcHeight = video.videoHeight;
-		const srcWidth = srcHeight * (9 / 16);
+		const srcWidth = video.videoHeight * (9 / 16);
+		const srcHeight = srcWidth * (4 / 3);
 		const sx = (video.videoWidth - srcWidth) / 2;
+		const sy = (video.videoHeight - srcHeight) / 2;
 
 		canvas.width = srcWidth;
 		canvas.height = srcHeight;
-		ctx.drawImage(video, sx, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight);
+		ctx.drawImage(
+			video,
+			sx,
+			sy,
+			srcWidth,
+			srcHeight,
+			0,
+			0,
+			srcWidth,
+			srcHeight,
+		);
 
 		return new Promise((resolve) => {
 			canvas.toBlob((blob) => resolve(blob), "image/jpeg", 0.8);

--- a/app/javascript/controllers/video_capture_controller.js
+++ b/app/javascript/controllers/video_capture_controller.js
@@ -75,14 +75,25 @@ export default class extends Controller {
 		const canvas = this.canvasTarget;
 		const ctx = canvas.getContext("2d");
 
-		const srcHeight = video.videoHeight;
-		const srcWidth = srcHeight * (9 / 16);
+		const srcWidth = video.videoHeight * (9 / 16);
+		const srcHeight = srcWidth * (4 / 3);
 		const sx = (video.videoWidth - srcWidth) / 2;
+		const sy = (video.videoHeight - srcHeight) / 2;
 
 		canvas.width = srcWidth;
 		canvas.height = srcHeight;
 
-		ctx.drawImage(video, sx, 0, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight);
+		ctx.drawImage(
+			video,
+			sx,
+			sy,
+			srcWidth,
+			srcHeight,
+			0,
+			0,
+			srcWidth,
+			srcHeight,
+		);
 
 		return new Promise((resolve) => {
 			canvas.toBlob((blob) => resolve(blob), "image/jpeg", 0.8);


### PR DESCRIPTION
# Issue
#107 

### 概要
現状は撮影プレビュー画面と実際に撮影される画像の比率は9 x 16で同一。プレビュー画面はそのままに、撮影画像の比率を3 x 4に変更する

### 実装方針
- 画角を計算しcanvasのサイズを変更。
- drawImageにsyの値を指定し上下をクロップする。