### PR TITLE
撮影画面にガイドラインを表示

### DIFF
--- a/app/views/shared/_photo_capture.html.slim
+++ b/app/views/shared/_photo_capture.html.slim
@@ -3,10 +3,13 @@ div.fixed.inset-0.z-50.bg-black.flex.flex-col.hidden data-photo-capture-target="
     video.w-full.h-full.object-cover data-photo-capture-target="video" autoplay playsinline muted
     canvas.hidden data-photo-capture-target="canvas"
     div.absolute.inset-0.bg-white.opacity-0.pointer-events-none.transition-opacity.duration-150 data-photo-capture-target="flash"
+    div.absolute.inset-x-0.border-b.border-white/50.pointer-events-none style="top: 12.5%"
+    div.absolute.inset-x-0.border-t.border-white/50.pointer-events-none style="bottom: 12.5%"
+    div.absolute.left-1/2.border-l.border-white/30.pointer-events-none style="top: 12.5%; bottom: 12.5%"
+    div.absolute.border.border-white/60.rounded-sm.pointer-events-none style="top: 18%; left: 20%; right: 20%; bottom: 40%"
     button.absolute.top-4.right-4.text-white.text-3xl type="button" aria-label="閉じる" data-action="click->photo-capture#close"
       | ✕
     button.absolute.bottom-6.left-1/2.-translate-x-1/2.w-16.h-16.rounded-full.border-4.border-white type="button" aria-label="撮影" data-action="click->photo-capture#capture"
-
   div.flex.items-center.justify-center.py-4.bg-black/80
     button.text-white.text-lg.font-bold.px-8.py-2.rounded-full.border.border-white type="button" data-action="click->photo-capture#complete"
       | OK

--- a/app/views/shared/_video_capture.html.slim
+++ b/app/views/shared/_video_capture.html.slim
@@ -2,6 +2,10 @@ div.fixed.inset-0.z-50.bg-black.hidden data-video-capture-target="screen"
   div class="relative mx-auto aspect-9/16 max-h-[90vh] overflow-hidden"
     video.w-full.h-full.object-cover data-video-capture-target="video" autoplay playsinline muted
     canvas.hidden data-video-capture-target="canvas"
+    div.absolute.inset-x-0.border-b.border-white/50.pointer-events-none style="top: 12.5%"
+    div.absolute.inset-x-0.border-t.border-white/50.pointer-events-none style="bottom: 12.5%"
+    div.absolute.left-1/2.border-l.border-white/30.pointer-events-none style="top: 12.5%; bottom: 12.5%"
+    div.absolute.border.border-white/60.rounded-sm.pointer-events-none style="top: 18%; left: 20%; right: 20%; bottom: 40%"
     span.absolute.top-4.left-4.text-red-500.font-bold.hidden data-video-capture-target="rec"
       | REC
     button.absolute.top-4.right-4.text-white.text-3xl type="button" aria-label="閉じる" data-action="click->video-capture#close"


### PR DESCRIPTION
### Issue
#140 

### 概要
撮影画面にガイド線を表示する。

### 実装方針
- Canvasのクロップ領域を示す上下のボーダーを表示
- 顔の撮影位置の目安としてボックスを表示