### PR TITLE
AI回答の例外処理を追加する

### DIFF
--- a/app/jobs/process_ai_response_job.rb
+++ b/app/jobs/process_ai_response_job.rb
@@ -1,7 +1,53 @@
 class ProcessAiResponseJob < ApplicationJob
   queue_as :default
 
+  server_error_msg = "サーバーに接続できませんでした。しばらく経ってからもう一度お試しください"
+  request_error_msg = "アクセスが集中しています。しばらく時間を空けてお試しください。"
+  client_error_msg = "エラーが発生しました"
+
+  retry_on Faraday::ConnectionFailed, wait: 10.seconds, attempts: 3 do |job, error|
+    session = job.arguments.first[:session]
+    Rails.logger.error("[Gemini] #{error.class}: #{error.message} | #{error.backtrace&.first(3)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, server_error_msg)
+  end
+
+  retry_on Faraday::TimeoutError, wait: 10.seconds, attempts: 3 do |job, error|
+    session = job.arguments.first[:session]
+    Rails.logger.error("[Gemini] #{error.class}: #{error.message} | #{error.backtrace&.first(3)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, server_error_msg)
+  end
+
+  discard_on Faraday::SSLError do |job, error|
+    session = job.arguments.first[:session]
+    Rails.logger.error("[Gemini] #{error.class}: #{error.message} | #{error.backtrace&.first(3)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, server_error_msg)
+  end
+
+  retry_on Gemini::Errors::RequestError, wait: 10.seconds, attempts: 3 do |job, error|
+    session = job.arguments.first[:session]
+    status = error.request&.response&.dig(:status) || "unknown"
+    Rails.logger.error("[Gemini][#{status}] #{error.class}: #{error.message} | #{error.backtrace&.first(4)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, server_error_msg)
+  end
+
+  discard_on Faraday::ClientError do |job, error|
+    session = job.arguments.first[:session]
+    Rails.logger.error("[Gemini] #{error.class}: #{error.message} | #{error.backtrace&.first(3)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, client_error_msg)
+  end
+
+  retry_on Faraday::TooManyRequestsError, wait: 15.seconds, attempts: 3 do |job, error|
+    session = job.arguments.first[:session]
+    status = error.response_status || "unknown"
+    body = error.response_body
+    Rails.logger.error("[Gemini][#{status}] #{error.class}: #{error.message} | details: #{body} | #{error.backtrace&.first(3)&.join(' <- ')}")
+    Gemini::ProcessAiResponse.return_error_message(session, request_error_msg)
+  end
+
   def perform(session:, message:, images: [])
+    if executions >= 1
+      Gemini::ProcessAiResponse.show_retry_counts(session, executions)
+    end
     image_attachments = message.image_attachments()
     chat_history = session.messages.where.not(id: message.id).order(:created_at)
     Gemini::ProcessAiResponse.call(

--- a/app/services/gemini/process_ai_response.rb
+++ b/app/services/gemini/process_ai_response.rb
@@ -87,4 +87,21 @@ class Gemini::ProcessAiResponse
       locals: { message: ai_message }
     )
   end
+
+  def self.return_error_message(session, message)
+    Turbo::StreamsChannel.broadcast_append_to(
+      session,
+      target: "chat",
+      partial: "messages/error_message",
+      locals: { message: message }
+    )
+  end
+
+  def self.show_retry_counts(session, executions)
+    Turbo::StreamsChannel.broadcast_update_to(
+      session,
+      target: "retry-counts",
+      html: "retrying... #{executions}/3"
+    )
+  end
 end

--- a/app/views/messages/_error_message.html.slim
+++ b/app/views/messages/_error_message.html.slim
@@ -1,0 +1,2 @@
+div.error-message
+  p = message

--- a/app/views/sessions/show.html.slim
+++ b/app/views/sessions/show.html.slim
@@ -16,10 +16,11 @@ dev.flex.flex-col.h-screen(
 
       - else
         = render "messages/ai_message", message: message, diagnosed_images: message.diagnosed_images
-      
+
     div.loader.hidden data-chat-target="loader"
       | loading...
-  
+      div#retry-counts
+
   = render "shared/image_preview"
   = render "shared/video_capture"
   = render "shared/photo_capture"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -3,7 +3,12 @@
 # not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
 # to make the web console appear.
 development:
-  adapter: async
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 test:
   adapter: test

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,12 +17,23 @@ default: &default
   encoding: unicode
   username: monalin
   password: password
+  host: db
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 
 development:
-  <<: *default
-  database: monalin_development
+  primary:
+    <<: *default
+    database: monalin_development
+  queue:
+    <<: *default
+    database: monalin_development_queue
+    migration_paths: db/queue_migrate
+  cable:
+    <<: *default
+    database: monalin_development_cable
+    migrations_paths: db/cable_migrate
+
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,4 +79,8 @@ Rails.application.configure do
   # set the delivery method using letter opener gem
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
+
+  # Enabele active job retry_on/discard/on options
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,7 +35,7 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] || Rails.env.development?
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,41 +1,56 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_094847) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
     t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
     t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
     t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
-    t.datetime "created_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
     t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.text "error"
     t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
     t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.string "class_name", null: false
-    t.text "arguments"
-    t.integer "priority", default: 0, null: false
     t.string "active_job_id"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
+    t.text "arguments"
+    t.string "class_name", null: false
     t.string "concurrency_key"
     t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
     t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
     t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
@@ -45,76 +60,76 @@ ActiveRecord::Schema[7.1].define(version: 1) do
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
-    t.string "queue_name", null: false
     t.datetime "created_at", null: false
+    t.string "queue_name", null: false
     t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
-    t.bigint "supervisor_id"
-    t.integer "pid", null: false
-    t.string "hostname"
     t.text "metadata"
-    t.datetime "created_at", null: false
     t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
     t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
     t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
     t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
     t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
     t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
     t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "task_key", null: false
-    t.datetime "run_at", null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
     t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "schedule", null: false
-    t.string "command", limit: 2048
-    t.string "class_name"
     t.text "arguments"
-    t.string "queue_name"
-    t.integer "priority", default: 0
-    t.boolean "static", default: true, null: false
-    t.text "description"
+    t.string "class_name"
+    t.string "command", limit: 2048
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
     t.datetime "updated_at", null: false
     t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
     t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
     t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.string "key", null: false
-    t.integer "value", default: 1, null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
     t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
     t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
     t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true


### PR DESCRIPTION
### Issue
#170

### 概要
gemini API通信次の例外に対する例外処理を追加する

### 実装方針
- gemini-ai gemの返す5xxエラーおよびFaraday gemの返すネットワークエラーおよび4xxエラーに対してActiveJobのretry_onで例外処理を追加する
- broadcast_update_toでretry回数をviewに通知する