### PR TITLE
フォーム送信時のバリデーションを追加

### DIFF
--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -1,13 +1,14 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-	static targets = ["loader", "container"];
+	static targets = ["loader", "container", "error"];
 
 	connect() {
 		this.startObserve();
 	}
 
 	startObserve() {
+		if (!this.hasContainerTarget) return;
 		const config = {
 			childList: true,
 			attributes: false,
@@ -35,6 +36,7 @@ export default class extends Controller {
 	}
 
 	showLoader() {
+		if (!this.hasLoaderTarget) return;
 		this.containerTarget.appendChild(this.loaderTarget);
 		this.loaderTarget.classList.remove("hidden");
 	}
@@ -44,6 +46,20 @@ export default class extends Controller {
 		if (stream.getAttribute("target") === "chat") {
 			this.loaderTarget.classList.add("hidden");
 		}
+	}
+
+	showError(e) {
+		if (!this.hasErrorTarget) return;
+		clearTimeout(this.errorTimer);
+		this.errorTarget.textContent = e.detail.message;
+		this.errorTarget.classList.replace("opacity-0", "opacity-100");
+		this.hideError();
+	}
+
+	hideError() {
+		this.errorTimer = setTimeout(() => {
+			this.errorTarget.classList.replace("opacity-100", "opacity-0");
+		}, 3000);
 	}
 
 	disconnect() {

--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -2,15 +2,28 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
 	static targets = ["input"];
+	static values = { message: Boolean };
 
 	async send(e) {
 		e.preventDefault();
-		if (this.inputTarget.value.trim() === "") return;
-
 		const body = this.inputTarget.value;
 		const blobs = await db.captures
 			.filter((c) => c.message_id === null)
 			.toArray();
+
+		if (this.messageValue === false && blobs.length === 0) {
+			this.dispatch("error", {
+				detail: { message: "最初に撮影を行なってください" },
+			});
+			return;
+		} else if (
+			this.messageValue === true &&
+			blobs.length === 0 &&
+			body === ""
+		) {
+			return;
+		}
+
 		const formData = new FormData();
 		formData.append("message[body]", body);
 		if (blobs.length > 0) {
@@ -42,8 +55,10 @@ export default class extends Controller {
 
 			if (response.status === 201) {
 				window.location.href = response.headers.get("Location");
+				this.messageValue = true;
 			} else {
 				this.appendMessage(body);
+				this.messageValue = true;
 			}
 		} catch (error) {
 			console.error("通信エラー:", error);

--- a/app/views/sessions/_form.html.slim
+++ b/app/views/sessions/_form.html.slim
@@ -5,13 +5,13 @@ div#chat-form.bottom-0.left-0.right-0.p-4.z-10.bg-page data-controller = "captur
       button type="button" aria-label="カメラ撮影" data-action="click->photo-capture#open" 📷 カメラ撮影
 
   - if session.persisted?
-    = form_with model: [session, Message.new], data: { controller: "chat-form", action: "submit->chat-form#send" }, class: "flex items-center gap-1" do |f|
+    = form_with model: [session, Message.new], data: { controller: "chat-form", action: "submit->chat-form#send", chat_form_message_value: session.messages.any? }, class: "flex items-center gap-1" do |f|
       button type="button" aria-label="撮影メニューを開く" class="text-xl" data-action="click->capture-menu#show" ＋
       div.relative.flex-1
         = f.text_area :body, placeholder: "メッセージを入力...", data: { chat_form_target: "input", action: "focus->capture-menu#hide" } ,class: "w-full border rounded-lg p-2 pr-10 resize-none field-sizing-content min-h-[4.5rem]"
         = f.submit "↑", aria: { label: "送信" }, class: "absolute right-2 bottom-2 rounded-full w-6 h-6"
   - else
-    = form_with model: Message.new, data: { controller: "chat-form", action: "submit->chat-form#send"} ,class: "flex items-center gap-2" do |f|
+    = form_with model: Message.new, data: { controller: "chat-form", action: "submit->chat-form#send", chat_form_message_value: session.messages.any? } ,class: "flex items-center gap-2" do |f|
       button type="button" aria-label="撮影メニューを開く" class="text-xl" data-action="click->capture-menu#show" ＋
       div.relative.flex-1
         = f.text_area :body, placeholder: "メッセージを入力...", data: { chat_form_target: "input", action: "focus->capture-menu#hide" } ,class: "w-full border rounded-lg p-2 pr-10 resize-none field-sizing-content min-h-[4.5rem]"

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,4 +1,4 @@
-section#new-session.p-4n
+section#new-session.p-4 data-controller="chat" data-action="chat-form:error->chat#showError"
   div.flex.flex-col.items-start
     span.mb-1 Monalin
     div.ai-instruction.bg-chat.rounded-lg.p-4.max-w-xs
@@ -6,6 +6,7 @@ section#new-session.p-4n
         | こんにちは！まずは下のアイコンから撮影してくださいね。
         = link_to "使い方", "#", class: "text-blue-500 underline ml-1"
 
+  div.text-center.opacity-0.transition-opacity.duration-500 data-chat-target="error"
   div.capture-icons.flex.flex-col.gap-2.justify-center.mt-8(
       data-controller="video-capture photo-capture photo-select"
       data-video-capture-prep-duration-value="5000"
@@ -15,7 +16,8 @@ section#new-session.p-4n
     )
     button type="button" aria-label="ビデオ撮影" class="text-3xl" data-action="click->video-capture#open" 📹
     button type="button" aria-label="カメラ撮影" class="text-2xl" data-action="click->photo-capture#open" 📷
-   
+
+
     = render "shared/video_capture"
     = render "shared/photo_capture"
     = render "shared/photo_select"


### PR DESCRIPTION
### Issue
#114 

### 概要
フォーム送信時の簡易的なバリデーションを実装する

### バリデーション条件
**新規チャットの場合(画像添付必須)**
送信OK: 画像とメッセージ、または画像のみ
送信NG: メッセージのみ、またはどちらも空

**既存チャットの場合**
画像とメッセージどちらも空はNG。それ以外はOK。
