### PR TITLE
初回のフォーム送信時にローダーが表示されない不具合を修正

### DIFF
--- a/app/views/sessions/show.html.slim
+++ b/app/views/sessions/show.html.slim
@@ -17,7 +17,8 @@ dev.flex.flex-col.h-screen(
       - else
         = render "messages/ai_message", message: message, diagnosed_images: message.diagnosed_images
 
-    div.loader.hidden data-chat-target="loader"
+    - loader_visibility = @session.messages.last&.processing? ? "" : "hidden"
+    div.loader data-chat-target="loader" class="#{loader_visibility}"
       | loading...
       div#retry-counts
 


### PR DESCRIPTION
### Issue
#148 

### 概要
初回のフォーム送信時にローダーが表示されない。

### 実装方針
- show.html.slimのレンダリング時にmessage.status.last&.processing? === trueの場合にローダーを表示状態にする
- ローダーのその後の状態更新は従来通りのStimulusの制御でOK