### PR TITLE
本番環境のiPhoneでチャットが送信できない症状に対処

### DIFF
--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
 
 	async send(e) {
 		e.preventDefault();
+
 		const body = this.inputTarget.value;
 		const blobs = await db.captures
 			.filter((c) => c.message_id === null)
@@ -29,7 +30,8 @@ export default class extends Controller {
 		if (blobs.length > 0) {
 			blobs.forEach((b, i) => {
 				formData.append(`message[images][${i}][key]`, b.key);
-				formData.append(`message[images][${i}][blob]`, b.blob);
+				const blob = new Blob([b.blob], { type: b.type || "image/jpeg" });
+				formData.append(`message[images][${i}][blob]`, blob);
 			});
 		}
 

--- a/app/javascript/controllers/image_controller.js
+++ b/app/javascript/controllers/image_controller.js
@@ -41,7 +41,8 @@ export default class extends Controller {
 		if (records.length === 0) return;
 		for (const record of records) {
 			const img = document.createElement("img");
-			img.src = URL.createObjectURL(record.blob);
+			const blob = new Blob([record.blob], { type: record.type });
+			img.src = URL.createObjectURL(blob);
 			img.classList.add("w-full", "aspect-square", "object-cover", "rounded");
 			img.setAttribute("data-action", "click->image-preview#showImagePreview");
 			try {

--- a/app/javascript/controllers/photo_select_controller.js
+++ b/app/javascript/controllers/photo_select_controller.js
@@ -38,22 +38,30 @@ export default class extends Controller {
 			return;
 		}
 
-		if (selectedPhotos.length >= 5) {
+		if (selectedPhotos.length > 5) {
 			this.showError("同時に分析できる写真は5枚までです");
 			return;
 		}
 
-		for (const selectedPhoto of selectedPhotos) {
-			const index = parseInt(selectedPhoto.dataset.index);
-			const blob = this.photos[index];
-			await db.captures.add({
-				key: crypto.randomUUID(),
-				message_id: null,
-				blob: blob,
-				diagnose: null,
-				captured_at: new Date().toISOString(),
-			});
+		try {
+			for (const selectedPhoto of selectedPhotos) {
+				const index = parseInt(selectedPhoto.dataset.index);
+				const blob = this.photos[index];
+				const arrayBuffer = await blob.arrayBuffer();
+				await db.captures.add({
+					key: crypto.randomUUID(),
+					message_id: null,
+					blob: arrayBuffer,
+					type: blob.type,
+					diagnose: null,
+					captured_at: new Date().toISOString(),
+				});
+			}
+		} catch (e) {
+			this.showError(`IndexedDB save error:${e.message}`);
+			console.error("IndexedDB save error:", e);
 		}
+
 		this.close();
 	}
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,7 @@ Rails.application.configure do
   # Enabele active job retry_on/discard/on options
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+
+  # ngrok
+  config.hosts << /.*\.ngrok-free\.dev/
 end


### PR DESCRIPTION
### Issue
#152 

### 概要
本番環境のPCではチャットは正常動作するものの、iPhoneでは送信ができない

### 実装方針
- WebkitのChromeはSafariベースでindexedDBのblob読み書きにバグがあるため、arrayBufferに変換して保存し、読み出し時にblobに再変換するように変更
- ngrokを導入し開発環境のホストで動作検証する