### PR TITLE
AIチャット機能にバリデーションを追加する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,17 +266,17 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     oauth2 (2.0.18)
       faraday (>= 0.17.3, < 4.0)
@@ -681,12 +681,12 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.0) sha256=172076c4b30ce56fb25a03961b0c4da14e1246426401b0f89cba1a3b54bf3ef0
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
-  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
-  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
-  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
   oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,12 @@
 class MessagesController < ApplicationController
   def create
     @session = find_or_create_session
+
+    return if handle_invalid_post(message_params[:body], message_params[:images])
+
     @message = @session.messages.build(body: message_params[:body])
     @message.role = "user"
+
 
     if message_params[:images]
       message_params[:images].values.each do |image|
@@ -39,6 +43,19 @@ class MessagesController < ApplicationController
   end
 
   private
+
+  def handle_invalid_post(body, images)
+    if @session.messages.empty? && images.nil?
+      Rails.logger.warn("Invalid post: first message without images - user_id: #{current_user.id}")
+      render json: { message: "撮影してください" }, status: :unprocessable_entity
+      true
+    elsif @session.messages.any? && body.blank? && images.nil?
+      Rails.logger.warn("Invalid post: empty post - user_id: #{current_user.id}")
+      render json: { message: "メッセージを入力してください" }, status: :unprocessable_entity
+      true
+    end
+  end
+
 
   def find_or_create_session
     if params[:session_id]

--- a/app/javascript/controllers/chat_form_controller.js
+++ b/app/javascript/controllers/chat_form_controller.js
@@ -45,6 +45,12 @@ export default class extends Controller {
 				},
 			});
 
+			if (response.status === 422) {
+				const res = await response.json();
+				this.dispatch("error", { detail: { message: res.message } });
+				return;
+			}
+
 			if (!response.ok) {
 				throw new Error(`予期せぬステータス: ${response.status}`);
 			}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,7 +3,11 @@ class Message < ApplicationRecord
   enum :status, { processing: "processing", completed: "completed", failed: "failed" }
   belongs_to :session
   has_many :image_attachments, dependent: :destroy
-  has_many :diagnosed_images, class_name: "ImageAttachment", foreign_key: :ai_message_id
+  has_many :diagnosed_images, class_name: "ImageAttachment", foreign_key: :ai_message_id, dependent: :nullify
+
+  validates :role, inclusion: { in: %w[user ai] }
+  validates :status, inclusion: { in: %w[processing completed failed] }
+  validates :body, length: { maximum: 500 }
 
   def mark_as_failed!
     update!(status: "failed")

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,5 @@
 class Session < ApplicationRecord
-  validates :session_title, presence: true, length: { maximum: 100 }
+  validates :session_title, presence: true, length: { maximum: 50 }
   has_many :messages, dependent: :destroy
 
   belongs_to :user

--- a/app/models/social_account.rb
+++ b/app/models/social_account.rb
@@ -1,3 +1,5 @@
 class SocialAccount < ApplicationRecord
   belongs_to :user
+
+  validates :uid, uniqueness: { scope: :provider }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   enum :status, { active: 0, suspended: 1, banned: 2 }
 
   validates :email, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
+  validetas :username, presence: true, length: { maximum: 24 }
 
   has_many :social_accounts, dependent: :destroy
   has_many :sessions, dependent: :destroy

--- a/db/migrate/20260510093811_add_constraints_to_image_attachments.rb
+++ b/db/migrate/20260510093811_add_constraints_to_image_attachments.rb
@@ -1,0 +1,7 @@
+class AddConstraintsToImageAttachments < ActiveRecord::Migration[8.1]
+  def change
+    add_foreign_key :image_attachments, :messages, column: :ai_message_id
+    add_index :image_attachments, :ai_message_id
+    change_column_null :image_attachments, :ai_message_id, true
+  end
+end

--- a/db/migrate/20260511003106_add_unique_constraint_to_image_attachments_object_key.rb
+++ b/db/migrate/20260511003106_add_unique_constraint_to_image_attachments_object_key.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToImageAttachmentsObjectKey < ActiveRecord::Migration[8.1]
+  def change
+    add_index :image_attachments, :object_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_052420) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_003106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,7 +22,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_052420) do
     t.bigint "message_id", null: false
     t.string "object_key", null: false
     t.datetime "updated_at", null: false
+    t.index ["ai_message_id"], name: "index_image_attachments_on_ai_message_id"
     t.index ["message_id"], name: "index_image_attachments_on_message_id"
+    t.index ["object_key"], name: "index_image_attachments_on_object_key", unique: true
   end
 
   create_table "messages", force: :cascade do |t|
@@ -70,6 +72,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_052420) do
   end
 
   add_foreign_key "image_attachments", "messages"
+  add_foreign_key "image_attachments", "messages", column: "ai_message_id"
   add_foreign_key "messages", "sessions"
   add_foreign_key "sessions", "users"
   add_foreign_key "social_accounts", "users"


### PR DESCRIPTION
### Issue
#156 

### 概要
DB、モデル、コントローラー各レイヤーに必要なバリデーションを追加する

### 主な実装内容
 - messageモデルにdependent: :nullifyを追加（AIメッセージ削除時に画像添付を削除せず、ai_message_idをnullに戻す）
- MessagesController#create: 
UXフロー外のフォーム送信に対し422を返し、クライアント側でハンドリング(既存のchat#showErrorでユーザーにエラー表示)